### PR TITLE
fix: address derivation is the same at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ You can offload your fuzzing job to Recon to run long duration jobs and share te
 ## Credits
 This template implements the [`EnumerableSet`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/structs/EnumerableSet.sol) contract from OpenZeppelin and the [`ERC20`](https://github.com/transmissions11/solmate/blob/main/src/tokens/ERC20.sol) contract from Solmate to reduce the number of dependencies and make it simpler to get started.
 
+## Limitations
+
+- Echidna `contractAddr` must be hardcoded due to how Echidna works
+- Medusa uses `deployerAddress` to deploy libraries, burning nonces, as a sidestep we use a random `deployerAddress` and set `CryticTester` address in `predeployedContracts` 
+
 ## Help
 
 If you need help using the template or have question about any of our tools, join the [Recon Discord](https://getrecon.xyz/discord).

--- a/echidna.yaml
+++ b/echidna.yaml
@@ -7,6 +7,6 @@ balanceAddr: 0x1043561a8829300000
 balanceContract: 0x1043561a8829300000
 filterFunctions: []
 cryticArgs: ["--foundry-compile-all"]
-deployer: "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496"
+deployer: "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38"
 contractAddr: "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496"
 shrinkLimit: 100000

--- a/medusa.json
+++ b/medusa.json
@@ -8,7 +8,7 @@
     "corpusDirectory": "medusa",
     "coverageEnabled": true,
     "deploymentOrder": [
-      "CryticTester"
+
     ],
     "targetContracts": [
       "CryticTester"
@@ -16,8 +16,11 @@
     "targetContractsBalances": [
       "0x27b46536c66c8e3000000"
     ],
+    "predeployedContracts": {
+      "CryticTester": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496"
+    },
     "constructorArgs": {},
-    "deployerAddress": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+    "deployerAddress": "0xf5e4fFeB7d2183B61753AA4074d72E51873C1D0a",
     "senderAddresses": [
       "0x10000",
       "0x20000",


### PR DESCRIPTION
Fixes #23 

Hardcodes addresses in Echidna (no changes)

Sidesteppes Medusa logic by:
- Using another deployer address (msg.sender)
- Hardcoding the contract address via `predeployedContracts`