### PR TITLE
Feat foundry profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ echidna
 crytic-export
 slither_results.json
 .medusacache
+/foundry/corpus

--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ forge test --match-contract CryticToFoundry -vv
 
 You can then use optimization mode to increase the severity of findings as we've described [here](https://book.getrecon.xyz/writing_invariant_tests/optimizing_broken_properties.html).
 
+#### Foundry Invariant Testing
+To run invariant tests directly in Foundry using the built-in invariant testing framework, use the `invariants` profile:
+
+```shell
+FOUNDRY_PROFILE=invariants forge test --match-contract CryticToFoundry -vv
+```
+
+The number of test runs can be modified by the `runs` parameter in the `[profile.invariants.invariant]` section of `foundry.toml`.
+
 ### Halmos Invariant Testing
 This template works out of the box for invariant testing with Halmos.
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,7 +8,7 @@ viaIR = true
 no_match_contract = "CryticTester" ## Skip Echinda / Medusa boilerplate
 
 [invariant]
-runs = 0 # Only flag properties that insta break
+runs = 0 # Only flag properties that break without calls
 
 [profile.invariants]
 ## Custom Profile used to run invariant tests

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,8 +2,23 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-no_match_contract = "CryticTester"
 
-optimizer=false ## Required by Crytic-Comile
+viaIR = true
 
+no_match_contract = "CryticTester" ## Skip Echinda / Medusa boilerplate
+
+[invariant]
+runs = 0 # Only flag properties that insta break
+
+[profile.invariants]
+## Custom Profile used to run invariant tests
+match_test = ""
+[profile.invariants.invariant]
+runs = 1_000_000 ## Test this param! Generally speaking this needs to be very high!
+corpus_dir = "./foundry/corpus"
+corpus_gzip = false
+corpus_min_mutations = 5
+corpus_min_size = 0
+
+# Learn about chimera: https://book.getrecon.xyz/writing_invariant_tests/chimera_framework.html
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -9,7 +9,11 @@ import {Test} from "forge-std/Test.sol";
 import {TargetFunctions} from "./TargetFunctions.sol";
 
 
+// Debug Broken Repros
 // forge test --match-contract CryticToFoundry -vv
+
+// Run Invariant Tests
+//  FOUNDRY_PROFILE=invariants forge test --match-contract CryticToFoundry -vv --show-progress
 contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
     function setUp() public {
         setup();

--- a/test/recon/CryticToFoundry.sol
+++ b/test/recon/CryticToFoundry.sol
@@ -13,7 +13,7 @@ import {TargetFunctions} from "./TargetFunctions.sol";
 // forge test --match-contract CryticToFoundry -vv
 
 // Run Invariant Tests
-//  FOUNDRY_PROFILE=invariants forge test --match-contract CryticToFoundry -vv --show-progress
+// FOUNDRY_PROFILE=invariants forge test --match-contract CryticToFoundry -vv --show-progress
 contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
     function setUp() public {
         setup();


### PR DESCRIPTION
Introduces 2 profiles

This makes it so that by default we do not run invariant tests (more appropriately we run the invariants for zero runs)

We then have a separate profile for Coverage Guided Fuzzing